### PR TITLE
82017 - Fix release build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           ISHUSERNAME: ${{ secrets.ISHUSERNAME }}
           ISHKEY: ${{ secrets.ISHKEY }}
-          JAVA_OPTS: "-Xmx1024M -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512M"
+          JAVA_OPTS: "-Xmx1024M -XX:ReservedCodeCacheSize=512M"
           GRADLE_OPTS: "-Dorg.gradle.daemon=true"
         run: ./gradlew test build :publishIntershopMvnPublicationToMavenRepository -s --scan
       - name: Post Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           ISHUSERNAME: ${{ secrets.ISHUSERNAME }}
           ISHKEY: ${{ secrets.ISHKEY }}
-          JAVA_OPTS: "-Xmx1024M -XX:MaxPermSize=512M -XX:ReservedCodeCacheSize=512M"
+          JAVA_OPTS: "-Xmx1024M -XX:ReservedCodeCacheSize=512M"
           GRADLE_OPTS: "-Dorg.gradle.daemon=true"
         run: ./gradlew -PrunOnCI=true test build :publishIntershopMvnPublicationToMavenRepository :publishPlugins -s --scan
       - name: Post Build

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Include to build.gradle
 <pre>
 buildscript {
     dependencies {
-        classpath 'com.intershop.gradle.architectural.report:architectural-report-gradle-plugin:2.1.0'
+        classpath 'com.intershop.gradle.architectural.report:architectural-report-gradle-plugin:2.1.1'
     }
 }
 apply plugin: 'com.intershop.gradle.architectural.report'

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
     // artifact signing - necessary on Maven Central
     id 'signing'
 
-    id 'com.gradle.plugin-publish' version '0.10.0'
+    id 'com.gradle.plugin-publish' version '0.21.0'
 }
 
 // release configuration

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ description 'Gradle architectural report plugin'
 
 // adapt external loading at ArchitectureReportPlugin and README.md too
 // IMPORTANT version referenced at com.intershop.tool.architecture.report.plugin.ArchitectureReportPlugin
-version = '2.1.0'
+version = '2.1.1'
 // IMPORTANT version referenced at com.intershop.tool.architecture.report.plugin.ArchitectureReportPlugin
 
 sourceCompatibility = 1.8

--- a/src/main/groovy/com/intershop/tool/architecture/report/plugin/ArchitectureReportPlugin.groovy
+++ b/src/main/groovy/com/intershop/tool/architecture/report/plugin/ArchitectureReportPlugin.groovy
@@ -57,7 +57,7 @@ class ArchitectureReportPlugin implements Plugin<Project> {
                     .defaultDependencies { dependencies ->
                 DependencyHandler dependencyHandler = project.getDependencies()
 
-                dependencies.add(dependencyHandler.create('com.intershop.gradle.architectural.report:architectural-report-gradle-plugin:2.1.0'))
+                dependencies.add(dependencyHandler.create('com.intershop.gradle.architectural.report:architectural-report-gradle-plugin:2.1.1'))
                 dependencies.add(dependencyHandler.create('org.slf4j:slf4j-api:1.7.25'))
                 dependencies.add(dependencyHandler.create('org.ow2.asm:asm:7.0'))
                 dependencies.add(dependencyHandler.create('javax.inject:javax.inject:1'))


### PR DESCRIPTION
PR to fix the release build in the Architecture Report Plugin for ICM 7.10.
The previously used Gradle publish plugin version 0.10.0 contained the vulnerability CVE-2020-7599, therefore it was blocked by the Gradle plugin server.
Also, the from JDK 8 on unsupported MaxPermSize JVM flag was removed.
For more information, see related issue with ID 82017 in the Azure board.